### PR TITLE
Added markup for container styles in base view and in empty tile

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,8 @@ Changelog
   [arsenico13]
 - Update some italian translations.
   [arsenico13]
+- Fix templates for container styles in base view and in empty tile handling
+  [nzambello]
 
 
 1.1.1 (2018-03-06)

--- a/src/collective/tiles/collection/browser/templates/base_view.pt
+++ b/src/collective/tiles/collection/browser/templates/base_view.pt
@@ -7,53 +7,57 @@
       i18n:domain="collective.tiles.collection">
   <body>
     <metal:macro define-macro="collection-tile-macro">
-      <h3 tal:define="title view/data/title|nothing;"
-          class="tileTitle"
-          tal:condition="title">${title}</h3>
-      <div class="tileBody">
-        <p tal:condition="not:results"
-           class="noResults"
-           i18n:translate="tiles_collection_noresults">
-         No results found
-        </p>
-        <ul class="tileContent" tal:condition="results">
-          <tal:results tal:repeat="obj results">
-            <li tal:define="oddrow repeat/obj/odd;
-                            useView python:obj.portal_type in viewActions;
-                            itemUrl python:useView and obj.getURL() + '/view' or obj.getURL();
-                            item_wf_state obj/review_state;
-                            item_wf_state_class python:'state-' + plone_view.normalizeString(item_wf_state);
-                            item_type obj/portal_type;
-                            item_type_class python:'contenttype-' + plone_view.normalizeString(item_type);"
-                tal:attributes="class python:oddrow and 'collectionItem even' or 'collectionItem odd'">
-                <a href="#"
-                   tal:attributes="href itemUrl;
-                                   class string:tile $item_type_class $item_wf_state_class;
-                                   title obj/Description">
-                    <img class="image-icon"
-                       tal:define="thumb python:obj.getURL()+'/@@images/image/icon'"
-                       tal:condition=" obj/getIcon"
-                       tal:attributes="href obj/getURL;
-                                       src  string:$thumb;">
-                    <span tal:replace="obj/Title">
-                     Title </span>
-                    <span class="tileItemDetails"
-                          tal:condition="python:view.data.get('show_dates', False)"
-                          tal:define="obj_date obj/Date"
-                          tal:content="python:toLocalizedTime(obj_date)">
-                        Date
-                    </span>
-                </a>
-            </li>
-          </tal:results>
-        </ul>
-        <div class="showMore" tal:condition="view/data/show_more">
-          <a href="${collection/absolute_url}"
-             tal:define="show_more_label view/data/show_more_label|nothing">
-            <span tal:condition="not:show_more_label"
-                  i18n:translate="more_url">More&hellip;</span>
-            <span tal:condition="show_more_label">${show_more_label}</span>
-          </a>
+      <div class="tile-collection">
+        <div class="tile-collection-container">
+          <h3 tal:define="title view/data/title|nothing;"
+              class="tileTitle"
+              tal:condition="title">${title}</h3>
+          <div class="tileBody">
+            <p tal:condition="not:results"
+               class="noResults"
+               i18n:translate="tiles_collection_noresults">
+             No results found
+            </p>
+            <ul class="tileContent" tal:condition="results">
+              <tal:results tal:repeat="obj results">
+                <li tal:define="oddrow repeat/obj/odd;
+                                useView python:obj.portal_type in viewActions;
+                                itemUrl python:useView and obj.getURL() + '/view' or obj.getURL();
+                                item_wf_state obj/review_state;
+                                item_wf_state_class python:'state-' + plone_view.normalizeString(item_wf_state);
+                                item_type obj/portal_type;
+                                item_type_class python:'contenttype-' + plone_view.normalizeString(item_type);"
+                    tal:attributes="class python:oddrow and 'collectionItem even' or 'collectionItem odd'">
+                    <a href="#"
+                       tal:attributes="href itemUrl;
+                                       class string:tile $item_type_class $item_wf_state_class;
+                                       title obj/Description">
+                        <img class="image-icon"
+                           tal:define="thumb python:obj.getURL()+'/@@images/image/icon'"
+                           tal:condition=" obj/getIcon"
+                           tal:attributes="href obj/getURL;
+                                           src  string:$thumb;">
+                        <span tal:replace="obj/Title">
+                         Title </span>
+                        <span class="tileItemDetails"
+                              tal:condition="python:view.data.get('show_dates', False)"
+                              tal:define="obj_date obj/Date"
+                              tal:content="python:toLocalizedTime(obj_date)">
+                            Date
+                        </span>
+                    </a>
+                </li>
+              </tal:results>
+            </ul>
+            <div class="showMore" tal:condition="view/data/show_more">
+              <a href="${collection/absolute_url}"
+                 tal:define="show_more_label view/data/show_more_label|nothing">
+                <span tal:condition="not:show_more_label"
+                      i18n:translate="more_url">More&hellip;</span>
+                <span tal:condition="show_more_label">${show_more_label}</span>
+              </a>
+            </div>
+          </div>
         </div>
       </div>
     </metal:macro>

--- a/src/collective/tiles/collection/browser/templates/collection_tile.pt
+++ b/src/collective/tiles/collection/browser/templates/collection_tile.pt
@@ -27,13 +27,17 @@
                            data-tileid tile_id"
            tal:condition="not:results">
          <tal:checkperm tal:condition="view/can_edit">
-           <h3 tal:define="title view/data/title|nothing;"
-               class="tileTitle"
-               tal:condition="title">${title}</h3>
-           <p class="noResults"
-              i18n:translate="tiles_collection_nothing_to_show">
-              Tile not rendered cause there is no content to show.
-           </p>
+          <div class="tile-collection empty">
+            <div class="tile-collection-container">
+               <h3 tal:define="title view/data/title|nothing;"
+                   class="tileTitle"
+                   tal:condition="title">${title}</h3>
+               <p class="noResults"
+                  i18n:translate="tiles_collection_nothing_to_show">
+                  Tile not rendered cause there is no content to show.
+               </p>
+             </div>
+           </div>
          </tal:checkperm>
       </div>
     </tal:block>


### PR DESCRIPTION
I wrapped the default template and the markup of the empty tile in two `<div>` useful to add styles (one is specific for a container).

Without this, it'd be impossible to set a container around an empty tile. If every tile has a container, an empty one would have the whole page width.
In this way, it can be ignored, or extended by themes with appropriate styles.