### PR TITLE
Avoid errors when getting collection by UID.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 2.1.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Avoid error when getting collection by UID.
+  [daniele]
 
 
 2.1.0 (2023-11-28)

--- a/src/collective/tiles/collection/collection.py
+++ b/src/collective/tiles/collection/collection.py
@@ -17,7 +17,10 @@ class CollectionTile(tiles.PersistentTile):
         collection_uid = self.data.get('collection_uid')
         if not collection_uid:
             return None
-        return api.content.get(UID=collection_uid)
+        try:
+            return api.content.get(UID=collection_uid)
+        except:
+            return None
 
     @property
     @view.memoize


### PR DESCRIPTION
Avoid errors when getting collection by UID. 

E.g. error related to permissions:

```
raise Unauthorized(text)
AccessControl.unauthorized.Unauthorized: Your user account does not have the required permission.  Access to 'collezione-canali-newsletter' of (Folder at /portale/la-camera/newsletter) denied. Your user account, Anonymous User, exists at /acl_users. Access requires View_Permission, granted to the following roles: ['Contributor', 'Editor', 'Manager', 'Owner', 'Reader', 'Site Administrator']. Your roles in this context are ['Anonymous'].
```